### PR TITLE
Ez-953-images in entity browser resolved and remove gin.css file from…

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -126,6 +126,10 @@ div.autocomplete-deluxe-container input.autocomplete-deluxe-form {
     max-width: 212px!important;
 }
 
+.gin-entity-browser .entity-browser-form .view-content {
+  display: block;
+}
+
 /* article node */
 #snippet_preview {
   width: auto;

--- a/ezcontent_admin.info.yml
+++ b/ezcontent_admin.info.yml
@@ -137,11 +137,6 @@ libraries-override:
       theme:
         css/paragraphs_ee.off_canvas.css: false
 
-  #   we used the gin.css in ezcontent_admin theme for style the our theme, but every-time when gin theme will be updated the version, we have to replace the gin.css by update one in our admin theme. but we have remove it and link with gin theme css file. (if when gin theme will be updated in the future we, don't need to replace in admin theme, it will updated self ) #
-  gin/dist: 
-    css:
-      gin.css: false
-
 libraries-extend:
   ckeditor/drupal.ckeditor:
     - claro/ckeditor-editor

--- a/ezcontent_admin.theme
+++ b/ezcontent_admin.theme
@@ -12,3 +12,18 @@ function ezcontent_admin_preprocess_page(&$variables) {
   $activeThemeName = \Drupal::theme()->getActiveTheme()->getName();
   $variables['active_admin_theme'] = $activeThemeName;
 }
+
+/**
+ * Set Gin CSS on top of all other CSS files.
+ */
+function ezcontent_admin_css_alter(&$css, $assets) {
+  // UPDATE THIS PATH TO YOUR MODULE'S CSS PATH.
+  $path = drupal_get_path('theme', 'ezcontent_admin') . '/css/style.css';
+
+  if (isset($css[$path])) {
+    // Use anything greater than 100 to have it load after the theme
+    // as CSS_AGGREGATE_THEME is set to 100.
+    // Let's be on the safe side and assign a high number to it.
+    $css[$path]['group'] = 200;
+  }
+}


### PR DESCRIPTION
images issue in entity browser resolved and remove gin.css file from ezcontent_admin.info.yml because its not needed as a base theme gin.css coming  by-default from from gin theme.