### PR TITLE
Ez-953-images-design-entity-browser-patch resolved by patch and css o…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   "extra": {
     "patches": {
       "drupal/gin": {
-        "3219236 - layout width issue in responsiveness on mobile/small device": "https://www.drupal.org/files/issues/2021-06-17/layout-width-issue-responsiveness-mobile-3219236-4.patch"
+        "3219236 - layout width issue in responsiveness on mobile/small device": "https://www.drupal.org/files/issues/2021-06-17/layout-width-issue-responsiveness-mobile-3219236-4.patch",
+        "3194254 - [media_entity_browser] Choose media styling": "https://www.drupal.org/files/issues/2021-06-22/media_entity_browser_Choose_media_styling_3194254_14.patch"
       }
     }
   },

--- a/ezcontent_admin.info.yml
+++ b/ezcontent_admin.info.yml
@@ -137,11 +137,6 @@ libraries-override:
       theme:
         css/paragraphs_ee.off_canvas.css: false
 
-  #   we used the gin.css in ezcontent_admin theme for style the our theme, but every-time when gin theme will be updated the version, we have to replace the gin.css by update one in our admin theme. but we have remove it and link with gin theme css file. (if when gin theme will be updated in the future we, don't need to replace in admin theme, it will updated self ) #
-  gin/dist: 
-    css:
-      gin.css: false
-
 libraries-extend:
   ckeditor/drupal.ckeditor:
     - claro/ckeditor-editor

--- a/ezcontent_admin.theme
+++ b/ezcontent_admin.theme
@@ -12,3 +12,18 @@ function ezcontent_admin_preprocess_page(&$variables) {
   $activeThemeName = \Drupal::theme()->getActiveTheme()->getName();
   $variables['active_admin_theme'] = $activeThemeName;
 }
+
+/**
+ * Set Gin CSS on top of all other CSS files.
+ */
+function ezcontent_admin_css_alter(&$css, $assets) {
+  // UPDATE THIS PATH TO YOUR MODULE'S CSS PATH.
+  $path = drupal_get_path('theme', 'ezcontent_admin') . '/css/style.css';
+
+  if (isset($css[$path])) {
+    // Use anything greater than 100 to have it load after the theme
+    // as CSS_AGGREGATE_THEME is set to 100.
+    // Let's be on the safe side and assign a high number to it.
+    $css[$path]['group'] = 200;
+  }
+}


### PR DESCRIPTION
resolved by patch and css ordering change for both file (gin.css and style.css) and remove gin path from info.yml, because its not needed as a base theme gin.css coming by-default from from gin theme.